### PR TITLE
Updated fuzzit to use release rather than debug

### DIFF
--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -30,7 +30,7 @@ function fuzz {
     (
         cd $DIR
         cargo fuzz run $FUZZER -- -runs=0
-        $ROOT/fuzzit create job --type $TYPE $TARGET ./fuzz/target/x86_64-unknown-linux-gnu/debug/$FUZZER
+        $ROOT/fuzzit create job --type $TYPE $TARGET ./fuzz/target/x86_64-unknown-linux-gnu/release/$FUZZER
     )
 }
 fuzz parser parse meta


### PR DESCRIPTION
fuzzit generates binaries in release rather than debug; the fuzzit script is looking for
them in debug. I updated the script to reflect this.